### PR TITLE
Added "none" as a label position option and now respects the checkbox's disabled state

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ If you want to apply something to all the inputs but you need a few specific one
       </td>
       <td>
         string<br>
-        <em>left, right(default)</em>
+        <em>left, right(default), none</em>
       </td>
       <td>
         <p>This is the position where the label for the inputs should be placed, if informed.</p>
@@ -130,7 +130,7 @@ If you want to apply something to all the inputs but you need a few specific one
       </td>
       <td>
         string<br>
-        <em>left, right(default)</em>
+        <em>left, right(default), none</em>
       </td>
       <td>
         <p>This is the position where the label for the inputs should be placed, if informed.</p>

--- a/prettyCheckable.css
+++ b/prettyCheckable.css
@@ -55,3 +55,6 @@
   margin: 6px 5px;
   cursor: pointer;
 }
+.prettycheckbox a.checkboxDisabled {
+    opacity: 0.5;
+}

--- a/prettyCheckable.js
+++ b/prettyCheckable.js
@@ -34,7 +34,11 @@
         var clickedParent = $(this).closest('.clearfix');
         var input = clickedParent.find('input');
         var fakeCheckable = clickedParent.find('a');
-
+        
+        if (input.attr('disabled')) {
+            return;
+        }
+        
         if (input.attr('type') == 'radio') {
 
           $('input[name="' + input.attr('name') + '"]').each(function(index, el){
@@ -92,16 +96,16 @@
       var dom = [];
       var isChecked = el.attr('checked') !== undefined ? 'checked' : '';
 
-      if (labelPosition === 'labelright') {
+      var checkboxDisabled = el.attr('disabled') !== undefined ? 'checkboxDisabled' : '';
 
-        dom.push('<a href="#" class="' + isChecked + '"></a>');
-        dom.push('<label for="' + el.attr('id') + '">' + label + '</label>');
-
+      if (labelPosition === 'labelnone') {
+          dom.push('<a href="#" class="' + isChecked + ' ' + checkboxDisabled + '"></a>');
+      } else if (labelPosition === 'labelleft') {
+          dom.push('<label for="' + el.attr('id') + '">' + label + '</label>');
+          dom.push('<a href="#" class="' + isChecked + ' ' + checkboxDisabled + '"></a>');
       } else {
-
-        dom.push('<label for="' + el.attr('id') + '">' + label + '</label>');
-        dom.push('<a href="#" class="' + isChecked + '"></a>');
-
+          dom.push('<a href="#" class="' + isChecked + ' ' + checkboxDisabled + '"></a>');
+          dom.push('<label for="' + el.attr('id') + '">' + label + '</label>');
       }
 
       el.parent().append(dom.join('\n'));


### PR DESCRIPTION
I've made a couple useful changes to hold the project over until more formal features have been implemented.

One change is to respect the original checkbox's disabled state. I added a new class to give the checkbox a disabled look by using opacity and made the link unclickable. I think the better approach to the disabled look would be extending the checkbox image to include disabled versions, but I'm not good enough with photoshop to update the psd.

The other addition was to make a label position of none so that a label isn't displayed when it's not required.

I've never done a pull request before, so I hope this works.
