### PR TITLE
checked class applied on change event

### DIFF
--- a/prettyCheckable.js
+++ b/prettyCheckable.js
@@ -25,56 +25,24 @@
       this.init();
     }
 
-    function addCheckableEvents(element) {
-
-      element.find('a, label').on('touchstart click', function(e){
-
-        e.preventDefault();
-
-        var clickedParent = $(this).closest('.clearfix');
-        var input = clickedParent.find('input');
-        var fakeCheckable = clickedParent.find('a');
-
-        if (input.prop('disabled') === true) {
-          console.log('sdf');
-          return;
-
-        }
-
-        if (input.prop('type') === 'radio') {
-
-          $('input[name="' + input.attr('name') + '"]').each(function(index, el){
-
-            $(el).prop('checked', false).parent().find('a').removeClass('checked');
-
-          });
-
-        }
-
-        if (input.prop('checked')) {
-
-            input.prop('checked', false).change();
-
-        } else {
-
-            input.prop('checked', true).change();
-
-        }
-
-        fakeCheckable.toggleClass('checked');
-
-      });
-
-      element.find('a').on('keyup', function(e){
-
-        if (e.keyCode === 32) {
-
-          $(this).click();
-
-        }
-
-      });
-
+    function addCheckableEvents(input){
+        input.on('change', function(){
+            input.siblings('a').toggleClass('checked', this.checked);
+        });
+        input.siblings('a, label')
+            .on('click',  function(event){
+                event.preventDefault();
+                event.stopImmediatePropagation();
+                input.trigger('click');
+                if (input.attr('type') == 'radio') {
+                    $('input[name="' + input.attr('name') + '"]').not(input).change();
+                }
+            })
+            .on('keyup', function(e){
+                if (e.keyCode === 32){
+                    $(this).click();
+                }
+            });
     }
 
     Plugin.prototype.init = function () {
@@ -116,7 +84,7 @@
       }
 
       el.parent().append(dom.join('\n'));
-      addCheckableEvents(el.parent());
+      addCheckableEvents(el);
 
     };
 


### PR DESCRIPTION
relative to : https://github.com/arthurgouveia/prettyCheckable/issues/28

I think it makes more sense to set the "checked" class regarding the input change event rather than the click event. Then to programmatically set a prettyCheckbox state, we just have to call :

```
$input_wrapper.find(":checkbox").prop("checked", isChecked).change();
```

This kinda redirects the click event to the input tag, so the "disabled" behaviour should be handled natively now.

Jasmine tests passed 5/5 (very useful BTW)
This is my first pull request, so I hope I didn't make any mistakes.
