### PR TITLE
Option to disable click event on label

### DIFF
--- a/dev/prettyCheckable.js
+++ b/dev/prettyCheckable.js
@@ -14,6 +14,7 @@
             label: '',
             labelPosition: 'right',
             customClass: '',
+            labelNotClickable:false,
             color: 'blue'
         };
 
@@ -55,6 +56,12 @@
                 input = clickedParent.find('input'),
                 fakeCheckable = clickedParent.find('a');
 
+            if ($(this).hasClass('notClickable') === true) {
+            	
+            	return;
+            	
+            }
+            
             if (fakeCheckable.hasClass('disabled') === true) {
 
                 return;
@@ -128,6 +135,8 @@
 
             var labelPosition = el.data('labelposition') !== undefined ? 'label' + el.data('labelposition') : 'label' + this.options.labelPosition;
 
+            var labelNotClickable = this.options.labelNotClickable === true ? 'notClickable' : '';
+            
             var customClass = el.data('customclass') !== undefined ? el.data('customclass') : this.options.customClass;
 
             var color =  el.data('color') !== undefined ? el.data('color') : this.options.color;
@@ -144,11 +153,11 @@
             if (labelPosition === 'labelright') {
 
                 dom.push('<a href="#" class="' + isChecked + ' ' + disabled + '"></a>');
-                dom.push('<label for="' + el.attr('id') + '">' + label + '</label>');
+                dom.push('<label class="' + labelNotClickable + '" for="' + el.attr('id') + '">' + label + '</label>');
 
             } else {
 
-                dom.push('<label for="' + el.attr('id') + '">' + label + '</label>');
+                dom.push('<label class="' + labelNotClickable + '" for="' + el.attr('id') + '">' + label + '</label>');
                 dom.push('<a href="#" class="' + isChecked + ' ' + disabled + '"></a>');
 
             }

--- a/dev/prettyCheckable.scss
+++ b/dev/prettyCheckable.scss
@@ -35,6 +35,9 @@ $sprite: sprite-map("sprites/*.png", $layout: "horizontal");
         float: left;
         margin: 6px 5px;
         cursor: pointer;
+		&.notClickable{
+			cursor: default;
+		}
     }
 
     a,


### PR DESCRIPTION
A quick solution to disable the click event on selected labels.
Useful to have hyperlinks for example:

<pre><code>$('#terms').prettyCheckable({
    labelNotClickable:true,
    label: 'I am ok with the &lt;span id="link"&gt;General Terms and Conditions&lt;/span&gt;!'
});
$('#link').on('click',function(e){
    window.open(url);
});
</code></pre>
