### PR TITLE
Changed how the UI's kept in sync

### DIFF
--- a/dev/prettyCheckable.js
+++ b/dev/prettyCheckable.js
@@ -77,20 +77,12 @@
                 ko.utils.triggerEvent(input[0], 'click');
 
             } else {
-
-                if (input.prop('checked')) {
-
-                    input.prop('checked', false).change();
-
-                } else {
-
-                    input.prop('checked', true).change();
-
-                }
+            	
+            	input.prop('checked', !input.prop('checked'));
+            	
+                input.change();
 
             }
-
-            fakeCheckable.toggleClass('checked');
 
         });
 
@@ -101,6 +93,12 @@
                 $(this).click();
 
             }
+
+        });
+
+        element.find('input').on('change.'+pluginName, function(e){	// add pluginName namespace for the event so it's easier to remove
+
+       		$(this).data( dataPlugin ).updateChecked();
 
         });
 
@@ -182,9 +180,10 @@
 
         },
 
-        check: function () {
-
-            if ($(this.element).prop('type') === 'radio') {
+        updateChecked: function () {
+        	var checked=$(this.element).prop('checked');
+ 
+             if ($(this.element).prop('type') === 'radio') {
 
                 $('input[name="' + $(this.element).attr('name') + '"]').each(function(index, el){
 
@@ -194,13 +193,22 @@
 
             }
 
-            $(this.element).prop('checked', true).attr('checked', true).parent().find('a:first').addClass('checked');
+            $(this.element).parent().find('a:first')[checked?'addClass':'removeClass']('checked');
+        },
+
+        check: function () {
+        	
+        	$(this.element).prop('checked', true);
+        	
+        	this.updateChecked();
 
         },
 
         uncheck: function () {
 
-            $(this.element).prop('checked', false).attr('checked', false).parent().find('a:first').removeClass('checked');
+        	$(this.element).prop('checked', false);
+        	
+        	this.updateChecked();
 
         },
 


### PR DESCRIPTION
This allows the UI to stay in sync even if the INPUT is toggled by code
outside of the plugin (either by JS or by the browser if the user clicks
a wrapping LABEL for example)

Calling `fakeCheckable.toggleClass('checked');` has the downside of not actually syncing the UI but just switching its state which in most cases is fine. But there are also cases when the source INPUT is toggled directly in some of various ways and then the UI can't catch up no matter how many times the user actions on the plugin's DOM elements.

There's only one concern I have about this commit and it relates to my complete ignorance regarding the Knockout library, and being unable to test if ko functionality is affected.

Also in `destroy()` it seems the source INPUT will be deleted from the DOM so there's no real need to detach events bound to it. But am I wrong?

Cheers
