### PR TITLE
support for input item wrapped with <label> tag

### DIFF
--- a/dev/prettyCheckable.js
+++ b/dev/prettyCheckable.js
@@ -126,7 +126,8 @@
             var classType = el.data('type') !== undefined ? el.data('type') : el.attr('type');
 
             var label = null,
-                elLabelId = el.attr('id');
+                elLabelId = el.attr('id'),
+                parentIsLabel = false;
 
             if (elLabelId !== undefined) {
 
@@ -137,6 +138,12 @@
                     label = elLabel.text();
 
                     elLabel.remove();
+
+                }  else if(el.closest('label').length > 0) {
+
+                    label = el.closest('label').text();
+
+                    parentIsLabel = true;
 
                 }
 
@@ -178,6 +185,11 @@
             }
 
             el.parent().append(dom.join('\n'));
+
+            if(parentIsLabel){
+                el.parent().parent().replaceWith(el.parent());
+            }
+
             addCheckableEvents(el.parent());
 
         },


### PR DESCRIPTION
The case like below is not supported by old code:
&lt;label&gt;
  &lt;input type="checkbox" /&gt;
  Some label string
&lt;label&gt;

This is popular case, so this modification must be useful.
